### PR TITLE
fixed issue with 2fa

### DIFF
--- a/srcs/backend/src/models/user.model.ts
+++ b/srcs/backend/src/models/user.model.ts
@@ -68,14 +68,25 @@ export async function updateProfilePic(db: Database, id: string, profile: string
 	return (result);
 }
 
-export async function update2faSecret(db: Database, id: string, twofa_method: string, twofa_secret: string){
+export async function update2faMethod(db: Database, id: string, twofa_method: string){
 	const date = getTimestamp();
 	const result = await db.run(
 		`UPDATE users
-		SET twofa_method = ?, twofa_enabled = ?, twofa_secret = ?, updated_at = ?
+		SET twofa_method = ?, twofa_enabled = ?, updated_at = ?
 		WHERE id = ?`,
-		[twofa_method, true, twofa_secret, date, id]
+		[twofa_method, true, date, id]
 		);
+	return (result);
+}
+
+export async function updateOnlySecret(db:Database, id: string, twofa_secret: string) {
+	const date = getTimestamp();
+	const result = await db.run(
+		`UPDATE users
+		SET twofa_secret = ?, updated_at = ?
+		where id = ?`,
+		[twofa_secret, date, id]
+	);
 	return (result);
 }
 

--- a/srcs/frontend/.gitignore
+++ b/srcs/frontend/.gitignore
@@ -12,6 +12,9 @@ dist
 dist-ssr
 secrets
 *.local
+.env
+.env.production
+.env.development
 
 # Editor directories and files
 .vscode/*

--- a/srcs/frontend/src/handlers/2faHandler.ts
+++ b/srcs/frontend/src/handlers/2faHandler.ts
@@ -77,7 +77,7 @@ export function initTwoFAToggleEmail(checkboxId: string) {
 	}})
 }
 
-export function verify2faHandler(buttonId: string, inputId: string) {
+export function verify2faHandler(buttonId: string, inputId: string, twofa_method: string) {
   const button = document.getElementById(buttonId) as HTMLButtonElement;
   const input = document.getElementById(inputId) as HTMLInputElement;
   const qrSection = document.getElementById("twofa-section") as HTMLElement;
@@ -103,7 +103,8 @@ export function verify2faHandler(buttonId: string, inputId: string) {
 			credentials: "include",
 			body: JSON.stringify({
 			id: userId,
-			token: token
+			token: token,
+			twofa_method: twofa_method
 		}),
 	});
 
@@ -137,12 +138,12 @@ export function verify2faLoginHandler(buttonId: string, inputId: string) {
 	button.addEventListener("click", async () => {
 	const token = input.value.trim();
 	const userId = localStorage.getItem("id");
+	const twofa_method = localStorage.getItem("twofa_method");
 
 	if (!token || !userId) {
 		alert("Please enter the 6-digit code.");
 		return;
 	}
-
 	try {
 		const res = await fetch("http://localhost:3000/2fa/verify", {
 			method: "POST",
@@ -150,7 +151,8 @@ export function verify2faLoginHandler(buttonId: string, inputId: string) {
 			credentials: "include",
 			body: JSON.stringify({
 			id: userId,
-			token: token
+			token: token,
+			twofa_method: twofa_method
 		}),
 	});
 

--- a/srcs/frontend/src/handlers/loginHandler.ts
+++ b/srcs/frontend/src/handlers/loginHandler.ts
@@ -10,8 +10,6 @@ export async function loginHandler(formId: string) {
 		e.preventDefault(); //prevent reload
 		const email = (document.getElementById("email") as HTMLInputElement).value;
 		const password = (document.getElementById("password") as HTMLInputElement).value;
-		//const loginForm = document.getElementById("login-form") as HTMLFormElement;
-		//const email2fa = document.getElementById("email2fa-input") as HTMLElement;
 
 		if (localStorage.getItem("id")) {
 			console.log("Already logged in, skipping login request");
@@ -32,6 +30,7 @@ export async function loginHandler(formId: string) {
 				const loginForm = document.getElementById("login-form") as HTMLFormElement;
 				const email2fa = document.getElementById("email2fa-input") as HTMLElement;
 				localStorage.setItem("id", data.id);
+				localStorage.setItem("twofa_method", data.twofa_method);
 				loginForm.classList.add("hidden");
 				email2fa.classList.remove("hidden");
 			}

--- a/srcs/frontend/src/profile.ts
+++ b/srcs/frontend/src/profile.ts
@@ -148,8 +148,8 @@ export async function renderProfilePage(container: HTMLElement) {
 		profilepicHandler("file-input");
 		initTwoFAToggle("toggle-2fa");
 		initTwoFAToggleEmail("toggle-2fa-email");
-		verify2faHandler("verify-2fa-app", "twofa-token-app");
-		verify2faHandler("verify-2fa-email", "twofa-token-email");
+		verify2faHandler("verify-2fa-app", "twofa-token-app", "totp");
+		verify2faHandler("verify-2fa-email", "twofa-token-email", "email");
 		initTwoFAMutualExclusion(user.twofa_method);
 
 	} catch (error) {


### PR DESCRIPTION
**Issue**
1. When 2FA process is not completed fully, it still sets the twofa_enabled as true.

This PR fixes this issue by separating updateOnlySecret and update2faMethod. During set up, it only saves the secret but does not set twofa_enabled to true. This boolean will only be set as true as the user keys in a valid 6 digit code and verifies.
If the user has not verified yet, the user will not encounter the request for 2fa on login.